### PR TITLE
gather_faces: force

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -181,7 +181,11 @@ class PlayIterator:
 
         self._host_states = {}
         start_at_matched = False
-        for host in inventory.get_hosts(self._play.hosts):
+        if self._play.gather_facts == 'ignore_restrictions':
+            hosts = inventory.get_hosts(self._play.hosts, ignore_limits_and_restrictions=True)
+        else:
+            hosts = inventory.get_hosts(self._play.hosts)
+        for host in hosts:
             self._host_states[host.name] = HostState(blocks=self._blocks)
             # if the host's name is in the variable manager's fact cache, then set
             # its _gathered_facts flag to true for smart gathering tests later
@@ -285,7 +289,9 @@ class PlayIterator:
                     # NOT explicitly set gather_facts to False.
 
                     gathering = C.DEFAULT_GATHERING
-                    implied = self._play.gather_facts is None or boolean(self._play.gather_facts)
+                    implied = (self._play.gather_facts is None or
+                               self._play.gather_facts == 'True' or
+                               self._play.gather_facts == 'ignore_restrictions')
 
                     if (gathering == 'implicit' and implied) or \
                        (gathering == 'explicit' and boolean(self._play.gather_facts)) or \

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -63,7 +63,7 @@ class Play(Base, Taggable, Become):
     _accelerate_port     = FieldAttribute(isa='int', default=5099, always_post_validate=True)
 
     # Connection
-    _gather_facts        = FieldAttribute(isa='bool', default=None, always_post_validate=True)
+    _gather_facts        = FieldAttribute(isa='string', default=None, always_post_validate=True)
     _gather_subset       = FieldAttribute(isa='list', default=None, always_post_validate=True)
     _hosts               = FieldAttribute(isa='list', required=True, listof=string_types, always_post_validate=True)
     _name                = FieldAttribute(isa='string', default='', always_post_validate=True)


### PR DESCRIPTION
**For review and feedback only.  Don't merge**

_Let's also take this time to consider changing `force` to `unrestricted` or `ignore_limits` or something, because it may be less than representative of the actual functionality_.

This commit adds `gather_facts: force` functionality to Ansible 2.x, affecting only currently the `linear` strategy, which was the default way in which Ansible 1.x series ran plays.  See [here](https://docs.ansible.com/ansible/playbooks_strategies.html) for more info on strategies.

This is a good starting point since we don't really know definitively how running our current playbooks would be affected by a new strategy.

My biggest concern with my implementation is here (or below): https://github.com/angstwad/ansible/blob/55bc67c81afc06d771b1996fa69d9de6483e24d0/lib/ansible/playbook/play.py#L66
This turns a former boolean value into a string, which is might be evaluated elsewhere expecting a boolean (and a string of any non-zero length value evaluates to `True`) so this might be an issue elsewhere.  I didn't see anything but I could have missed it.

In my test env, I had a 3 node group called `vms`.  

My test playbook:  

```

---
- name: This is a test play
  hosts: vms
  gather_facts: force
  tasks:
    - name: Display a message
      debug:
        msg: Hello World!
```

Running with `force` yields: 

```
$ ansible-playbook -i hosts --limit vm1 test.yml

PLAY [This is a test play] *****************************************************

TASK [setup] *******************************************************************
ok: [vm1]
ok: [vm2]
ok: [vm3]

TASK [Display a message] *******************************************************
ok: [vm1] => {
    "msg": "Hello World!"
}

PLAY RECAP *********************************************************************
vm1                        : ok=2    changed=0    unreachable=0    failed=0
vm2                        : ok=1    changed=0    unreachable=0    failed=0
vm3                        : ok=1    changed=0    unreachable=0    failed=0
```

Running with `yes` yields:

```
$ ansible-playbook -i hosts --limit vm1 test.yml

PLAY [This is a test play] *****************************************************

TASK [setup] *******************************************************************
ok: [vm1]

TASK [Display a message] *******************************************************
ok: [vm1] => {
    "msg": "Hello World!"
}

PLAY RECAP *********************************************************************
vm1                        : ok=2    changed=0    unreachable=0    failed=0
```

Running with `no` yields: 

```
$ ansible-playbook -i hosts --limit vm1 test.yml

PLAY [This is a test play] *****************************************************

TASK [Display a message] *******************************************************
ok: [vm1] => {
    "msg": "Hello World!"
}

PLAY RECAP *********************************************************************
vm1                        : ok=1    changed=0    unreachable=0    failed=0
```
